### PR TITLE
Safe model unpack

### DIFF
--- a/models/alexnet.lua
+++ b/models/alexnet.lua
@@ -12,15 +12,17 @@ require 'fbcoco'
 local utils = paths.dofile'model_utils.lua'
 
 local data = torch.load'data/models/imagenet_pretrained_alexnet.t7'
+local features = utils.safe_unpack(data.features)
+local top = utils.safe_unpack(data.top)
 
 local model = nn.Sequential()
   :add(nn.ParallelTable()
-    :add(utils.makeDataParallel(data.features:unpack()))
+    :add(utils.makeDataParallel(features))
     :add(nn.Identity())
   )
   :add(inn.ROIPooling(6,6,1/16))
   :add(nn.View(-1):setNumInputDims(3))
-  :add(data.top:unpack())
+  :add(top)
   :add(utils.classAndBBoxLinear(4096))
 
 model:cuda()

--- a/models/model_utils.lua
+++ b/models/model_utils.lua
@@ -250,6 +250,22 @@ function utils.conv345Combine(isNormalized, useConv3, useConv4, initCopyConv5)
   return pooling_join
 end
 
+-- workaround for bytecode incompat functions
+function utils.safe_unpack(self)
+   if self.unpack and self.model then
+      return self:unpack()
+   else
+      local model = self.model
+      for k,v in ipairs(model:listModules()) do
+         if v.weight and not v.gradWeight then
+            v.gradWeight = v.weight:clone()
+            v.gradBias = v.bias:clone()
+         end
+      end
+      return model
+   end
+end
+
 function utils.load(path)
   local data = torch.load(path)
   return data.unpack and data:unpack() or data

--- a/models/multipathnet.lua
+++ b/models/multipathnet.lua
@@ -24,8 +24,8 @@ print(model_opt)
 local N = 4
 
 local data = torch.load'data/models/imagenet_pretrained_vgg.t7'
-local features = data.features:unpack()
-local classifier = data.top:unpack()
+local features = utils.safe_unpack(data.features)
+local classifier = utils.safe_unpack(data.top)
 
 local model = nn.Sequential()
 


### PR DESCRIPTION
The error happens because function serialization changes in different versions of lua and luajit and unpack function can be loaded. This patch applies unpack if it couldn't be loaded.
Fixes https://github.com/facebookresearch/multipathnet/issues/33